### PR TITLE
Additional refinements to workflows

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,10 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,49 +1,33 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# and https://fromthebottomoftheheap.net/2020/04/30/rendering-your-readme-with-github-actions/
-# Workflow triggering derived from: https://stevenmortimer.com/running-github-actions-sequentially/
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  workflow_dispatch:
   push:
-    paths:
-      - 'README.Rmd'
+    paths: ['README.Rmd']
 
-name: Render README
+name: render-rmarkdown
 
 jobs:
-  render:
-    name: Render README
-    runs-on: macOS-latest
+  render-rmarkdown:
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::rmarkdown
-          needs: website
-
-      - name: Render README
-        run: Rscript -e 'rmarkdown::render("README.Rmd")'
-        
-      - name: Commit results
+      - uses: r-lib/actions/setup-renv@v2
+      
+      - name: Render Rmarkdown files and Commit Results
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git commit README.md -m 'Re-build README.Rmd' || echo "No changes to commit"
+          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
           git push origin || echo "No changes to commit"
-          
-      - name: Trigger pkgdown workflow
-        if: success()
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.ROPENGOV_WORKFLOWS_PAT }}
-          repository: ${{ github.repository }}
-          event-type: trigger-pkgdown-workflow
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
- Make check-standard run only on repository_dispatch (manually)
- Use the standard render-rmarkdown.yaml from https://github.com/r-lib/actions/tree/v2/examples and get rid of custom stuff